### PR TITLE
Added config arg to CTest args

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -530,7 +530,7 @@ module.exports = class Builder
 
         if(this._runTests)
         {
-            let ctestExecutor = cmake_utils.cmakeRunTestsExecutor(this._cpus, this._buildDir);
+            let ctestExecutor = cmake_utils.cmakeRunTestsExecutor(this._cpus, this._buildDir, this._config);
             this._action.addExecutor(new GroupExecutor(runTestsDescription, [ctestExecutor], core));
         }
 
@@ -640,9 +640,9 @@ function cmakeBuildExecutor(cpus, cmakeVersion, cmakeBuildDir, config)
     return new Executor(cmakeApp, buildParameters);
 }
 
-function cmakeRunTestsExecutor(cpus, cmakeBuildDir)
+function cmakeRunTestsExecutor(cpus, cmakeBuildDir, config)
 {
-    let args = [cmakeFlagE, cmakeChdirCommand, cmakeBuildDir, ctestApp, ctestOutputOnFailure];
+    let args = [cmakeFlagE, cmakeChdirCommand, cmakeBuildDir, ctestApp, ctestOutputOnFailure, cmakeFlagC, config];
     if(cpus > 1)
     {
         args.push(cmakeParallelParam);

--- a/src/builder.js
+++ b/src/builder.js
@@ -94,7 +94,7 @@ module.exports = class Builder
 
         if(this._runTests)
         {
-            let ctestExecutor = cmake_utils.cmakeRunTestsExecutor(this._cpus, this._buildDir);
+            let ctestExecutor = cmake_utils.cmakeRunTestsExecutor(this._cpus, this._buildDir, this._config);
             this._action.addExecutor(new GroupExecutor(runTestsDescription, [ctestExecutor], core));
         }
 

--- a/src/cmake_utils.js
+++ b/src/cmake_utils.js
@@ -86,9 +86,9 @@ function cmakeBuildExecutor(cpus, cmakeVersion, cmakeBuildDir, config)
     return new Executor(cmakeApp, buildParameters);
 }
 
-function cmakeRunTestsExecutor(cpus, cmakeBuildDir)
+function cmakeRunTestsExecutor(cpus, cmakeBuildDir, config)
 {
-    let args = [cmakeFlagE, cmakeChdirCommand, cmakeBuildDir, ctestApp, ctestOutputOnFailure];
+    let args = [cmakeFlagE, cmakeChdirCommand, cmakeBuildDir, ctestApp, ctestOutputOnFailure, cmakeFlagC, config];
     if(cpus > 1)
     {
         args.push(cmakeParallelParam);

--- a/test/CmakeUtilsTest.js
+++ b/test/CmakeUtilsTest.js
@@ -30,7 +30,7 @@ const ctestOutputOnFailure = '--output-on-failure';
 const cpackApp = 'cpack';
 
 const createDirArgs = [cmakeFlagE, cmakeMakedirectoryComand, cmakeBuildDir];
-const testArgs = [cmakeFlagE, cmakeChdirCommand, cmakeBuildDir, ctestApp, ctestOutputOnFailure];
+const testArgs = [cmakeFlagE, cmakeChdirCommand, cmakeBuildDir, ctestApp, ctestOutputOnFailure, cmakeFlagC, config];
 const packageArgs = [cmakeFlagE, cmakeChdirCommand, cmakeBuildDir, cpackApp, cmakeFlagG, cpakgGenerator, cmakeFlagC, config];
 const buildArgs = [cmakeBuildParam, cmakeBuildDir, cmakeConfigParam, config];
 const configureArgs_v312 = [cmakeFlagB, cmakeBuildDir, cmakeFlagS, cmakeSourceDir];
@@ -121,7 +121,7 @@ describe('cmake_utils', function() {
     });
 
     describe('cmakeRunTestsExecutor_cpu1', function() {
-        let cmakeExec = cmake_utils.cmakeRunTestsExecutor(1, cmakeBuildDir);
+        let cmakeExec = cmake_utils.cmakeRunTestsExecutor(1, cmakeBuildDir, config);
         let result = cmakeExec.execute((command, args)=>
         {
             it('Commands should be equal', function() {


### PR DESCRIPTION
I was receiving a `Test not available without configuration.  (Missing "-C <config>"?)` error when running ctest on a Windows host. This PR simply adds the `-C <config>` args to the ctest executor.